### PR TITLE
Removing comparison functionality

### DIFF
--- a/src/SharpOption.Core.Tests/SimpleOptionEqualityTests.generic.cs
+++ b/src/SharpOption.Core.Tests/SimpleOptionEqualityTests.generic.cs
@@ -1,7 +1,7 @@
 namespace SharpOption.Core.Tests;
 
 [Trait(CATEGORY, EQUALITY)]
-public class SimpleOptionComparisonTests
+public class SimpleOptionEqualityTests
 {
 	[Theory]
 	[InlineData(new object[] { 1, 1 })]
@@ -32,22 +32,10 @@ public class SimpleOptionComparisonTests
 	}
 
 	[Theory]
-	[InlineData(new object[] { 1, ">", 1, false })]
-	[InlineData(new object[] { 1, ">=", 1, true })]
-	[InlineData(new object[] { 1, "<", 1, false })]
-	[InlineData(new object[] { 1, "<=", 1, true })]
 	[InlineData(new object[] { 1, "==", 1, true })]
 	[InlineData(new object[] { 1, "!=", 1, false })]
-	[InlineData(new object[] { null!, ">", 1, false })]
-	[InlineData(new object[] { null!, ">=", 1, false })]
-	[InlineData(new object[] { null!, "<", 1, true })]
-	[InlineData(new object[] { null!, "<=", 1, true })]
 	[InlineData(new object[] { null!, "==", 1, false })]
 	[InlineData(new object[] { null!, "!=", 1, true })]
-	[InlineData(new object[] { 1, ">", null!, true })]
-	[InlineData(new object[] { 1, ">=", null!, true })]
-	[InlineData(new object[] { 1, "<", null!, false })]
-	[InlineData(new object[] { 1, "<=", null!, false })]
 	[InlineData(new object[] { 1, "==", null!, false })]
 	[InlineData(new object[] { 1, "!=", null!, true })]
 	public void Option_To_Option_Comparison(int? op1Value, string op, int? op2Value, bool expected)
@@ -59,10 +47,6 @@ public class SimpleOptionComparisonTests
 		// Act
 		var actual = op switch
 		{
-			">" => op1 > op2,
-			">=" => op1 >= op2,
-			"<" => op1 < op2,
-			"<=" => op1 <= op2,
 			"==" => op1 == op2,
 			"!=" => op1 != op2,
 			_ => throw new Exception("Invalid op in test data."),

--- a/src/SharpOption.Core/Option.cs
+++ b/src/SharpOption.Core/Option.cs
@@ -422,7 +422,7 @@ public static class Option
 /// Use the constructor functions <b><c>Option.Some&#60;T&#62;(...)</c></b> and <b><c>Option.None&#60;T&#62;()</c></b> to create values of this type.
 /// Use the functions in the <see langword="static"/> <see langword="class"/> <c>Option</c> to manipulate values of this type.
 /// </remarks>
-public record Option<T> : IStructuralEquatable, IStructuralComparable, IEquatable<T>, IEquatable<Option<T>>, IComparable, IComparable<Option<T>>
+public record Option<T>
 {
 	internal static Option<T> None { get; } = new(default, false);
 
@@ -455,19 +455,4 @@ public record Option<T> : IStructuralEquatable, IStructuralComparable, IEquatabl
 		: this(value, hasValue: true)
 	{
 	}
-
-
-	public bool Equals(T? other) => EqualityComparer<T>.Default.Equals(_value, other);
-	public bool Equals(object? other, IEqualityComparer comparer) => comparer.Equals(_value, other);
-	public int GetHashCode(IEqualityComparer comparer) => comparer.GetHashCode(_value!);
-	public override int GetHashCode() => GetHashCode(EqualityComparer<T>.Default);
-	public int CompareTo(object? other, IComparer comparer) => comparer.Compare(_value, other);
-	public int CompareTo(object? obj) => CompareTo(obj, Comparer<T>.Default);
-	public int CompareTo(Option<T>? other) => CompareTo(other is null ? default : other._value, Comparer<T>.Default);
-
-
-	public static bool operator <(Option<T> left, Option<T> right) => left.CompareTo(right) < 0;
-	public static bool operator <=(Option<T> left, Option<T> right) => left.CompareTo(right) <= 0;
-	public static bool operator >(Option<T> left, Option<T> right) => left.CompareTo(right) > 0;
-	public static bool operator >=(Option<T> left, Option<T> right) => left.CompareTo(right) >= 0;
 }

--- a/src/SharpOption.Core/ValueOption/ValueOption.cs
+++ b/src/SharpOption.Core/ValueOption/ValueOption.cs
@@ -418,7 +418,7 @@ public static class ValueOption
 /// Use the constructor functions <b><c>ValueOption.Some&#60;T&#62;(...)</c></b> and <b><c>ValueOption.None&#60;T&#62;()</c></b> to create values of this type.
 /// Use the functions in the <see langword="static"/> <see langword="class"/> <c>ValueOption</c> to manipulate values of this type.
 /// </remarks>
-public record struct ValueOption<T> : IStructuralEquatable, IStructuralComparable, IEquatable<T>, IEquatable<ValueOption<T>>, IComparable, IComparable<ValueOption<T>>
+public record struct ValueOption<T>
 {
 	internal static ValueOption<T> None { get; } = new(default, false);
 
@@ -451,19 +451,4 @@ public record struct ValueOption<T> : IStructuralEquatable, IStructuralComparabl
 		: this(value, hasValue: true)
 	{
 	}
-
-
-	public bool Equals(T? other) => EqualityComparer<T>.Default.Equals(_value, other);
-	public bool Equals(object? other, IEqualityComparer comparer) => comparer.Equals(_value, other);
-	public int GetHashCode(IEqualityComparer comparer) => comparer.GetHashCode(_value!);
-	public override int GetHashCode() => GetHashCode(EqualityComparer<T>.Default);
-	public int CompareTo(object? other, IComparer comparer) => comparer.Compare(_value, other);
-	public int CompareTo(object? obj) => CompareTo(obj, Comparer<T>.Default);
-	public int CompareTo(ValueOption<T> other) => CompareTo(other._value, Comparer<T>.Default);
-
-
-	public static bool operator <(ValueOption<T> left, ValueOption<T> right) => left.CompareTo(right) < 0;
-	public static bool operator <=(ValueOption<T> left, ValueOption<T> right) => left.CompareTo(right) <= 0;
-	public static bool operator >(ValueOption<T> left, ValueOption<T> right) => left.CompareTo(right) > 0;
-	public static bool operator >=(ValueOption<T> left, ValueOption<T> right) => left.CompareTo(right) >= 0;
 }


### PR DESCRIPTION
I didn't implement `Option<T>`/`ValueOption<T>`'s comparison logic to mirror F#'s option comparison (see https://stackoverflow.com/a/52220335/15357544). 

Also don't think F#'s option comparison logic will be a good fit in C# so I'll leave `Option<T>`/`ValueOption<T>` without it for now.